### PR TITLE
security: サプライチェーンハードニング対応（提案・自動生成）

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,15 +20,15 @@ jobs:
       - name: Set IMAGE_TAG env (traP branch)
         run: echo "IMAGE_TAG=latest" >> $GITHUB_ENV
         if: github.ref == 'refs/heads/traP'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
         with:
           registry: ghcr.io
           username: traptitech
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           context: .
           file: ./deployments/Dockerfile
@@ -43,7 +43,7 @@ jobs:
     needs: [image]
     steps:
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.STAGING_SSH_KEY }}
           known_hosts: ${{ secrets.STAGING_KNOWN_HOSTS }}

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   database:
-    image: postgres:11.6-alpine
+    image: postgres:11.6-alpine@sha256:c132d7802dcc127486a403fb9e9a52d9df2e3ab84037c5de8395ed6ba2743e20
     environment:
       - POSTGRES_USER=codimd
       - POSTGRES_PASSWORD=change_password


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> CI／サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・CI が通るかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。不要なものは部分的に revert／close いただいて構いません。

traPtitech org 全体のセキュリティ監査に基づく提案です。

> 🍴 **このリポジトリは fork です。** CI/Dockerfile は上流リポジトリ由来のため、修正は本来上流の責任範囲かもしれません。CI ハードニング（SHA 固定・digest 固定）のみ提案し、依存（package.json）は変更していません。

## 適用した変更

### ✅ GitHub Actions を commit SHA で固定（4 箇所）
タグ／ブランチ参照は可変で付け替えられ得るため、不変な commit SHA に固定しました（[pinact](https://github.com/suzuki-shunsuke/pinact) を使用）。`# vX` コメントを残しているので **Dependabot / Renovate は引き続き自動更新できます**。

### ✅ Docker ベースイメージを digest 固定（1 箇所）
信頼できる発行元（Docker 公式 / distroless / ghcr.io/traPtitech 等）の可変タグに `@sha256:...` を付与しました。
- `postgres:11.6-alpine`（`deployments/docker-compose.yml`）

## ⚠️ 要確認：信頼できる発行元か未確認の Docker image（自動変更していません）
以下は Docker 公式／検証済み発行元の判定ができなかった image です。**自動では変更していません。** 発行元の信頼性をご確認のうえ、問題なければ digest 固定を、不安なら公式イメージ等への置き換えをご検討ください。

- [ ] `hackmdio/buildpack:node-10-0baafb79`（`deployments/Dockerfile`）の発行元が信頼できることを確認した — CodiMD/HackMD 本家ベンダ (hackmdio) のイメージなので確認の上 digest 固定推奨
- [ ] `nabo.codimd.dev/hackmdio/hackmd:2.1.0`（`deployments/docker-compose.yml`）の発行元が信頼できることを確認した — 公式 CodiMD レジストリ (nabo.codimd.dev/hackmdio) の本家イメージなので確認の上 digest 固定推奨

## 確認のお願い
- [ ] CI が通ることを確認した

## 参考
- SHA pinning: [pinact](https://github.com/suzuki-shunsuke/pinact) ／ Dependabot（`github-actions`）・Renovate（`helpers:pinGitHubActionDigests`）でも自動更新できます
- [Docker Hardened Images](https://www.docker.com/ja-jp/products/hardened-images/)

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。